### PR TITLE
Finalize dynamic commitments for channel params

### DIFF
--- a/ext-dynamic-commitments.md
+++ b/ext-dynamic-commitments.md
@@ -270,6 +270,9 @@ The sending node:
     feature bit.
 
 The receiving node:
+  - if the channel is not quiescent:
+    - SHOULD send an `error` and close the connection.
+
   - if `channel_id` does not match an existing channel it has with the sender:
     - SHOULD send an `error` and close the connection.
   - MUST respond with either a `dyn_ack` or `dyn_reject`.
@@ -316,7 +319,7 @@ The receiving node:
   - if `channel_id` does not match an existing channel it has with the peer:
     - MUST send an `error` and close the connection.
   - if there isn't an outstanding `dyn_propose` it has sent:
-    - MUST send an `error` and fail the channel.
+    - MUST send an `error` and close the connection.
   - MUST verify the `signature` is valid for the same set of parameters proposed
     and signed by the channel peer's node identity private key.
   - MUST respond with a `dyn_commit` message.
@@ -363,7 +366,7 @@ The receiving node:
   - if `channel_id` does not match an existing channel it has with the peer
     - MUST close the connection
   - if there isn't an outstanding `dyn_propose` it has sent
-    - MUST send an `error` and fail the channel
+    - MUST send an `error` and close the connection.
   - MUST forget its last sent `dyn_propose` parameters.
   - if the `update_rejections` is a zero value
     - SHOULD NOT re-attempt another dynamic commitment negotiation for the

--- a/ext-dynamic-commitments.md
+++ b/ext-dynamic-commitments.md
@@ -88,6 +88,7 @@ remaining after we filter out these values is thus:
 - `to_self_delay`
 - `max_accepted_htlcs`
 - `funding_pubkey`
+- `channel_flags`
 - `channel_type`
 
 The design presented here is intended to allow for arbitrary changes to these
@@ -200,9 +201,17 @@ and are common to all messages in the negotiation phase.
   data:
     * [`u16`:`senders_max_accepted_htlcs`]
 
-#### channel_type
+#### channel_flags
 
 - type: 10
+
+  data:
+
+  - [`byte`: `channel_flags`]
+
+#### channel_type
+
+- type: 12
   data:
     * [`...*byte`:`channel_type`]
 
@@ -247,9 +256,12 @@ sent by the `initiator`.
     1. type: 8 (`max_accepted_htlcs`)
     2. data:
         * [`u16`:`senders_max_accepted_htlcs`]
-    1. type: 10 (`channel_type`)
+    1. type: 10 (`channel_flags`)
     2. data:
-        * [`...*byte`:`channel_type`]
+         - [`byte`: `channel_flags`]
+    1. type: 12 (`channel_type`)
+    2. data:
+         * [`...*byte`:`channel_type`]
 
 ##### Requirements
 

--- a/ext-dynamic-commitments.md
+++ b/ext-dynamic-commitments.md
@@ -474,7 +474,18 @@ constraints. A sketch is provided below:
         |       |--(5)---- revoke_and_ack ----->|       |
         +-------+                               +-------+
 
-At this point the channel is no longer considered quiescent.
+#### Terminate Quiescence
+
+A channel is no longer considered quiescent once a `revoke_and_ack` message is
+involved. Specifically, the initiator considers the channel active upon sending
+`revoke_and_ack`, while the responder considers it active upon receiving the
+message.
+
+A split view on the quiescence state is possible. For example, the initiator
+might immediately send an `update_add_htlc` after resuming channel operations,
+even while the responder is still processing the `revoke_and_ack`. This is
+acceptable, provided the responder caches the `update_add_htlc` and processes
+it later.
 
 ## Appendix A: `dyn_ack` signature definition
 

--- a/ext-dynamic-commitments.md
+++ b/ext-dynamic-commitments.md
@@ -107,8 +107,7 @@ However, there are exceptions to this protocol flow. Changing the funding pubkey
 and in certain cases, changing the channel type requires a funding output
 conversion. This proposal does not cover how to safely accomplish a funding
 output conversion and so for the purposes of the remainder of this document, it
-is considered prohibited. NOTE: follow-on documents will elaborate on how to
-execute changes that require funding output conversions.
+is considered prohibited.
 
 # Specification
 
@@ -128,7 +127,8 @@ state.
 
 In every dynamic commitment negotiation, there are two roles: the `initiator`
 and the `responder`. It is necessary for both nodes to agree on which node is
-the `initiator` and which node is the `responder`.
+the `initiator` and which node is the `responder`, which is determined during
+the quiescence negotiation.
 
 ### Negotiation TLVs
 
@@ -242,10 +242,6 @@ The receiving node:
   - if the TLV parameters of the `dyn_propose` are NOT acceptable and the
     receiver refuses to execute those parameter changes:
     - MUST respond with `dyn_reject`.
-
-_NOTE FOR REVIEWERS_: These messages all interact with each other, so feedback
-is welcome for how to restructure this section so that the invariants it
-prescribes are found in the most intuitive place.
 
 ##### Rationale
 
@@ -438,12 +434,6 @@ constraints. A sketch is provided below:
         +-------+                               +-------+
 
 At this point the channel is no longer considered quiescent.
-
-_NOTE FOR REVIEWERS_: Should we require that the `responder` immediately issues
-a `commitment_signed` of its own? As far as I can tell this doesn't accomplish
-anything except in the case where the `initiator` requests a change to its
-`dust_limit` which would give it _immediate_ (as opposed to _eventual_) access
-to a commitment transaction that abided by the new limit.
 
 ## Appendix A: `dyn_ack` signature definition
 

--- a/ext-dynamic-commitments.md
+++ b/ext-dynamic-commitments.md
@@ -117,6 +117,43 @@ current channel state machine. Assuming an agreement can be reached, we will
 proceed to the execution phase. During the execution phase, we apply the updates
 to the channel state machine.
 
+The overall flow is shown in the following diagram:
+
+```
+    +-------+                                     +-------+
+    |       |--(1)--- stfu ---------------------->|       |
+    |       |(Proposes entering quiescence)       |       |
+    |       |                                     |       |
+    |       |<-(2)----------------------- stfu ---|       |
+    |       |       (Agrees; channel is now quiet)|       |
+    |       |                                     |       |
+    |       |--(3)--- dyn_propose --------------->|       |
+    |       |(Proposes new channel terms)         |       |
+    |       |                                     |       |
+    |       |<-(4)-------------------- dyn_ack ---|       |
+    |       |       (Agrees to terms w/ signature)|       |
+    |       |                                     |       |
+    |       |--(5)--- dyn_commit ---------------->|       |
+    |   A   |(Bundles proposal and signature)     |   B   |
+    |       |                                     |       |
+    |       |--(6)--- commit_sig ---------------->|       |
+    |       |(Signs B's new commitment)           |       |
+    |       |                                     |       |
+    |       |<-(7)------------- revoke_and_ack ---|       |
+    |       |            (B revokes its old state)|       |
+    |       |                                     |       |
+    |       |<-(8)----------------- commit_sig ---|       |
+    |       |           (Signs A's new commitment)|       |
+    |       |                                     |       |
+    |       |--(9)--- revoke_and_ack ------------>|       |
+    |       |(A revokes its old state)            |       |
+    |       |                                     |       |
+    |       |  (Channel operates with new terms)  |       |
+    +-------+                                     +-------+
+```
+
+
+
 ## Proposal Phase
 
 As a prerequisite to the proposal phase of a Dynamic Commitment negotiation, the
@@ -431,6 +468,10 @@ constraints. A sketch is provided below:
         |   A   |--(2)------ commit_sig ------->|   B   |
         |       |                               |       |
         |       |<-(3)---- revoke_and_ack ------|       |
+        |       |                               |       |
+        |   A   |<-(4)------ commit_sig --------|   B   |
+        |       |                               |       |
+        |       |--(5)---- revoke_and_ack ----->|       |
         +-------+                               +-------+
 
 At this point the channel is no longer considered quiescent.


### PR DESCRIPTION
This PR builds on the [original draft plus some typo fixes](https://github.com/yyforyongyu/bolts/tree/ext-dyn), and we will focus on finalizing the channel params upgrade here. Notable changes are,

#### Exit Quiescence

Add a section to explicitly define when to exit the quiescent state for the sender and receiver, as required by BOLT02: 
>Dependent Protocols:
>- MUST specify all states that terminate quiescence.

#### `dyn_commit_sig`

We now bundle `dyn_commit` and `commit_sig` together to create a new message `dyn_commit_sig` and replace `dyn_commit`. This is a common source of complexity found in the specs - when a node is sending two msgs in a short time, e.g., `update_add_htlc` + `stfu`, or `revoke_and_ack` + `update_add_htlc` as described in this spec, it is prone to race. In this specific case, if the responder receives and **processes** `commit_sig` before `dyn_commit`, then we are in trouble. In addition, by combining these two msgs we can save ourselves a round of communication.

#### Change `channel_flags`

The original draft didn't include `channel_flags`, while it's a wanted feature, see https://github.com/lightningnetwork/lnd/issues/7902 and https://github.com/lightningnetwork/lnd/issues/9157. In specific,
- turning a public channel into a private one - since the channel has already been gossiped, we can send a disable flag to the network, tho there's no privacy gained. However this could enable users to turn existing channels into STC or custom channels.
- turning a private channel into a public one - this should be straightforward as we only need to generate new announcements to gossip the channel.

It's undecided if we want to enable this or not so it's a temp change.