### PR TITLE
Draft: Finalize dynamic commitments for channel type

### DIFF
--- a/ext-dynamic-commitments.md
+++ b/ext-dynamic-commitments.md
@@ -89,10 +89,16 @@ remaining after we filter out these values is thus:
 - `max_accepted_htlcs`
 - `funding_pubkey`
 - `channel_flags`
-- `channel_type`
+- channel_type<sup>*</sup>
 
 The design presented here is intended to allow for arbitrary changes to these
 values that currently have no facilities for change in any other way.
+
+<sup>*</sup>`channel_type` can be updated using Dynamic Commitments only if the
+funding output scripts are identical between the `channel_type` prior to the
+change and following it.
+
+TODO: list allowed channel_type conversions here.
 
 ## Design Overview
 


### PR DESCRIPTION
Will focus on channel type conversions that don't need kickoff txns.

I did some experiment [here](https://github.com/lightningnetwork/lnd/commit/b51b36521cb9f96c9b7dfdff5d6f931c74ffe0b8) to use a hybrid approach to upgrade an anchor channel to STC. This approach works without broadcasting any onchain txns, instead, it directly updates the next commitment tx to use the taproot outputs. Implementation-wide it seems simpler as,
- if the goal is to allow people routing taproot HTLCs, this achieves it without any onchain footprint. We also don't need to worry about gossip since STCs are private channels.
- we can then use splicing instead for future upgrades like PTLCs and the new gossip.
- implementation-wise it also seems easier - we only need to separate signing the funding output and signing the commitment txns to allow a hybrid channel like P2WSH funding output + taproot commitment outputs. Then we just keep the commitments in the revocation log as it is.

There are also downsides,
- it seems a bit ugly to have a hybrid channel, where we now break the `channel_type` into `funding_type` and `commitment_type`, not sure if it's an abstraction violation.
- we need to remember this change in the watchtower, sth like at commitment height X the outputs are taproot.
- it may have an impact on 3rd party tools to correctly identify and display the state of these channels.
- can we reuse the basepoints? is it cryptographically secure?

Given the discussion [here](https://delvingbitcoin.org/t/upgrading-existing-lightning-channels/881) and [here](https://github.com/lightning/bolts/pull/863#issuecomment-2070901974), we want to instead use splicing to perform funding output upgrade. Also chatted with Gemini, it seems to like the offchain upgrade approach, but also favors splicing in the long term. (Unfortunately the workspace account doesn't allow sharing conversation via a link, so I created this [gist](https://gist.github.com/yyforyongyu/94ddbefb86af11de814c2b5861ec618d)).

Looking for feedback here, meanwhile will implement channel params upgrade first.